### PR TITLE
Add order argument to queryset search

### DIFF
--- a/wagtailsearch/queryset.py
+++ b/wagtailsearch/queryset.py
@@ -10,15 +10,21 @@ class SearchableQuerySetMixin:
         fields=None,
         operator=None,
         order_by_relevance=True,
+        order=None,
         backend="default",
     ):
         """
         This runs a search query on all the items in the QuerySet
         """
         search_backend = get_search_backend(backend)
+        queryset = self
+        if order:
+            queryset = queryset.order_by(order)
+            order_by_relevance = False
+
         return search_backend.search(
             query,
-            self,
+            queryset,
             fields=fields,
             operator=operator,
             order_by_relevance=order_by_relevance,
@@ -30,15 +36,21 @@ class SearchableQuerySetMixin:
         fields=None,
         operator=None,
         order_by_relevance=True,
+        order=None,
         backend="default",
     ):
         """
         This runs an autocomplete query on all the items in the QuerySet
         """
         search_backend = get_search_backend(backend)
+        queryset = self
+        if order:
+            queryset = queryset.order_by(order)
+            order_by_relevance = False
+
         return search_backend.autocomplete(
             query,
-            self,
+            queryset,
             fields=fields,
             operator=operator,
             order_by_relevance=order_by_relevance,

--- a/wagtailsearch/test/tests/test_backends.py
+++ b/wagtailsearch/test/tests/test_backends.py
@@ -97,6 +97,29 @@ class BackendTests:
             ["JavaScript: The Definitive Guide"],
         )
 
+    def test_search_via_queryset_with_order_param(self):
+        results = models.Book.objects.search(
+            "JavaScript", backend=self.backend_name, order="number_of_pages"
+        )
+        self.assertEqual(
+            [r.title for r in results],
+            [
+                "JavaScript: The good parts",
+                "JavaScript: The Definitive Guide",
+            ],
+        )
+
+        results = models.Book.objects.search(
+            "JavaScript", backend=self.backend_name, order="-number_of_pages"
+        )
+        self.assertEqual(
+            [r.title for r in results],
+            [
+                "JavaScript: The Definitive Guide",
+                "JavaScript: The good parts",
+            ],
+        )
+
     def test_search_count(self):
         results = self.backend.search("JavaScript", models.Book)
         self.assertEqual(results.count(), 2)
@@ -336,6 +359,29 @@ class BackendTests:
             [r.title for r in results],
             [
                 "JavaScript: The Definitive Guide",
+            ],
+        )
+
+    def test_autocomplete_via_queryset_with_order_param(self):
+        results = models.Book.objects.autocomplete(
+            "JavaSc", backend=self.backend_name, order="number_of_pages"
+        )
+        self.assertEqual(
+            [r.title for r in results],
+            [
+                "JavaScript: The good parts",
+                "JavaScript: The Definitive Guide",
+            ],
+        )
+
+        results = models.Book.objects.autocomplete(
+            "JavaSc", backend=self.backend_name, order="-number_of_pages"
+        )
+        self.assertEqual(
+            [r.title for r in results],
+            [
+                "JavaScript: The Definitive Guide",
+                "JavaScript: The good parts",
             ],
         )
 


### PR DESCRIPTION
This serves as a shorthand for `queryset.order_by(some_field).search("foo", order_by_relevance=False)`.

Fixes #11